### PR TITLE
Execute "Right to be forgotten" on Sitecore Forms 

### DIFF
--- a/Habitat demo/src/Feature/FormsExtension/code/Sitecore.Weareyou.Feature.FormsExtension.csproj
+++ b/Habitat demo/src/Feature/FormsExtension/code/Sitecore.Weareyou.Feature.FormsExtension.csproj
@@ -46,7 +46,25 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Microsoft.Bcl.AsyncInterfaces.1.1.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.2.1.1\lib\netstandard2.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Logging, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Microsoft.Extensions.Logging.2.1.1\lib\netstandard2.0\Microsoft.Extensions.Logging.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=2.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Microsoft.Extensions.Logging.Abstractions.2.1.1\lib\netstandard2.0\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="Remotion.Linq, Version=2.2.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Remotion.Linq.2.2.0\lib\net45\Remotion.Linq.dll</HintPath>
+    </Reference>
     <Reference Include="Sitecore.Analytics, Version=13.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\Sitecore.Analytics.9.2.0\lib\net471\Sitecore.Analytics.dll</HintPath>
     </Reference>
@@ -59,6 +77,9 @@
     <Reference Include="Sitecore.ExperienceForms.Mvc, Version=3.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\Sitecore.ExperienceForms.Mvc.9.2.0\lib\net471\Sitecore.ExperienceForms.Mvc.dll</HintPath>
     </Reference>
+    <Reference Include="Sitecore.Framework.Conditions, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Sitecore.Framework.Conditions.4.0.0\lib\netstandard2.0\Sitecore.Framework.Conditions.dll</HintPath>
+    </Reference>
     <Reference Include="Sitecore.Kernel, Version=13.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\Sitecore.Kernel.9.2.0\lib\net471\Sitecore.Kernel.dll</HintPath>
     </Reference>
@@ -68,19 +89,48 @@
     <Reference Include="Sitecore.XConnect.Client, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\Sitecore.XConnect.Client.9.2.0\lib\netstandard2.0\Sitecore.XConnect.Client.dll</HintPath>
     </Reference>
+    <Reference Include="Sitecore.XConnect.Service.Plugins, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\packages\Sitecore.XConnect.Service.Plugins.9.2.0\lib\netstandard2.0\Sitecore.XConnect.Service.Plugins.dll</HintPath>
+    </Reference>
     <Reference Include="Sitecore.Xdb.MarketingAutomation.Core, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\packages\Sitecore.Xdb.MarketingAutomation.Core.9.2.0\lib\net471\Sitecore.Xdb.MarketingAutomation.Core.dll</HintPath>
     </Reference>
     <Reference Include="sysglobl" />
+    <Reference Include="System.Buffers, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\System.Buffers.4.4.0\lib\netstandard2.0\System.Buffers.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ComponentModel.Annotations, Version=4.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\System.ComponentModel.Annotations.4.7.0\lib\net461\System.ComponentModel.Annotations.dll</HintPath>
+    </Reference>
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Design" />
     <Reference Include="System.DirectoryServices" />
+    <Reference Include="System.Interactive.Async, Version=3.0.3000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\System.Interactive.Async.3.1.1\lib\net46\System.Interactive.Async.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Interactive.Async.Providers, Version=3.0.1000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\System.Interactive.Async.Providers.3.1.1\lib\net45\System.Interactive.Async.Providers.dll</HintPath>
+    </Reference>
     <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.IO.FileSystem.Primitives" />
+    <Reference Include="System.Memory, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\System.Memory.4.5.2\lib\netstandard2.0\System.Memory.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\System.Numerics.Vectors.4.4.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime.Caching" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.6.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\System.Runtime.CompilerServices.Unsafe.4.7.1\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime.InteropServices.RuntimeInformation" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.ServiceModel.Web" />
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\System.Threading.Tasks.Extensions.4.5.2\lib\netstandard2.0\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />
     <Reference Include="System.Web.ApplicationServices" />
@@ -119,6 +169,7 @@
     <Compile Include="Activities\DataManagementService.cs" />
     <Compile Include="Processing\Actions\SaveDataWithContact.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="XConnectServicePlugin\EraseFormSubmissionWhenExecutingRightToBeForgotten.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/Habitat demo/src/Feature/FormsExtension/code/XConnectServicePlugin/EraseFormSubmissionWhenExecutingRightToBeForgotten.cs
+++ b/Habitat demo/src/Feature/FormsExtension/code/XConnectServicePlugin/EraseFormSubmissionWhenExecutingRightToBeForgotten.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Linq;
 using Microsoft.Extensions.Logging;
 using Sitecore.Framework.Conditions;
 using Sitecore.Weareyou.Feature.FormsExtension.Activities;
+using Sitecore.Weareyou.Feature.FormsExtension.Processing.Actions;
 using Sitecore.XConnect;
 using Sitecore.XConnect.Operations;
 using Sitecore.XConnect.Service.Plugins;
@@ -82,7 +84,15 @@ namespace Sitecore.Weareyou.Feature.FormsExtension.XConnectServicePlugin
                 if (contactId.HasValue)
                 {
                     _logger.LogDebug($"[{PluginName}] Starting erasing {contactId.Value} contact records from Forms database");
-                    DataManagementService.DeleteFormEntries(contactId.Value);
+                    var identifier = entity.Identifiers
+                        .FirstOrDefault(i => i.Source.Equals(SaveDataWithContact.TrackerIdFieldName));
+                    if(identifier != null) { 
+                        if (Guid.TryParse(identifier?.Identifier, out var id))
+                        {
+                            DataManagementService.DeleteFormEntries(id);
+                        }
+                    }
+                    
                     _logger.LogDebug($"[{PluginName}] Erasing {contactId.Value} contact records from Forms database was finished");
                 }
             }

--- a/Habitat demo/src/Feature/FormsExtension/code/XConnectServicePlugin/EraseFormSubmissionWhenExecutingRightToBeForgotten.cs
+++ b/Habitat demo/src/Feature/FormsExtension/code/XConnectServicePlugin/EraseFormSubmissionWhenExecutingRightToBeForgotten.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using Microsoft.Extensions.Logging;
+using Sitecore.Framework.Conditions;
+using Sitecore.Weareyou.Feature.FormsExtension.Activities;
+using Sitecore.XConnect;
+using Sitecore.XConnect.Operations;
+using Sitecore.XConnect.Service.Plugins;
+
+namespace Sitecore.Weareyou.Feature.FormsExtension.XConnectServicePlugin
+{
+    /// <summary>
+    /// Implementation was inspired by Sitecore.EmailCampaign.XConnect.Operations.ClearSupressionListWhenExecutingRightToBeForgotten
+    /// XConnect service plugin that clears forms data on executing right to be forgotten
+    /// Makes Sitecore Forms to be GDPR compliant
+    /// e.g. Sitecore > xProfile > Any contact > Action > Anonymize
+    ///
+    /// To enable it you need to copy XML configuration to sc93xconnect.dev.local\App_Data\Config\Sitecore\Collection
+    /// Configuration is present in this repository Project\xConnect\code\App_data\config\sitecore\Collection\sc.XConnect.Service.Plugins.FormsAnonymize.xml
+    /// </summary>
+    public class EraseFormSubmissionWhenExecutingRightToBeForgotten : IXConnectServicePlugin, IDisposable
+    {
+        private const string PluginName = "EraseFormSubmissionWhenExecutingRightToBeForgotten";
+        private XdbContextConfiguration _configuration;
+        private readonly ILogger _logger;
+        private IDataManagementService DataManagementService { get; set; }
+        public EraseFormSubmissionWhenExecutingRightToBeForgotten(ILogger<EraseFormSubmissionWhenExecutingRightToBeForgotten> logger)
+        {
+            DataManagementService = new DataManagementService();
+            _logger = logger;
+        }
+        public void Dispose()
+        {
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Subscribes  to events
+        /// </summary>
+        /// <param name="config">XdbContextConfiguration</param>
+        public void Register(XdbContextConfiguration config)
+        {
+            _configuration = Condition.Requires(config, "config").IsNotNull().Value;
+            _configuration.OperationAdded += OnOperationAdded;
+        }
+
+        private void OnOperationAdded(object sender, XdbOperationEventArgs xdbOperationEventArgs)
+        {
+            Condition.Requires(xdbOperationEventArgs, "xdbOperationEventArgs").IsNotNull();
+            RightToBeForgottenOperation rightToBeForgottenOperation;
+            if ((rightToBeForgottenOperation = (xdbOperationEventArgs.Operation as RightToBeForgottenOperation)) != null)
+            {
+                if (rightToBeForgottenOperation.Status == XdbOperationStatus.Canceled)
+                {
+                    _logger.LogDebug($"[{PluginName}] Skipping operation as it has been cancelled");
+                }
+                else
+                {
+                    rightToBeForgottenOperation.DependencyAdded += OnDependencyAddedToRightToBeForgottenOperation;
+                }
+            }
+        }
+
+        private void OnDependencyAddedToRightToBeForgottenOperation(object sender, DependencyAddedEventArgs args)
+        {
+            Condition.Requires(args, "args").IsNotNull();
+            GetEntityOperation<Contact> getEntityOperation;
+            if ((getEntityOperation = (args.Predecessor as GetEntityOperation<Contact>)) != null)
+            {
+                getEntityOperation.StatusChanged += OnGetEntityOperationStatusChanged;
+            }
+        }
+
+        private void OnGetEntityOperationStatusChanged(object sender, StatusChangedEventArgs args)
+        {
+            Condition.Requires(sender, "sender").IsNotNull();
+            Condition.Requires(args, "args").IsNotNull();
+            GetEntityOperation<Contact> getEntityOperation;
+            if ((getEntityOperation = (sender as GetEntityOperation<Contact>)) != null && args.NewStatus == XdbOperationStatus.Succeeded)
+            {
+                var entity = getEntityOperation.Entity;
+                var contactId = entity.Id;
+                if (contactId.HasValue)
+                {
+                    _logger.LogDebug($"[{PluginName}] Starting erasing {contactId.Value} contact records from Forms database");
+                    DataManagementService.DeleteFormEntries(contactId.Value);
+                    _logger.LogDebug($"[{PluginName}] Erasing {contactId.Value} contact records from Forms database was finished");
+                }
+            }
+        }
+
+        public void Unregister()
+        {
+            _configuration.OperationAdded -= OnOperationAdded;
+        }
+    }
+}

--- a/Habitat demo/src/Feature/FormsExtension/code/packages.config
+++ b/Habitat demo/src/Feature/FormsExtension/code/packages.config
@@ -1,12 +1,28 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="1.1.0" targetFramework="net471" />
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="2.0.1" targetFramework="net471" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.1.1" targetFramework="net471" />
+  <package id="Microsoft.Extensions.Logging" version="2.1.1" targetFramework="net471" />
+  <package id="Microsoft.Extensions.Logging.Abstractions" version="2.1.1" targetFramework="net471" />
+  <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net471" />
+  <package id="Remotion.Linq" version="2.2.0" targetFramework="net471" />
   <package id="Sitecore.Analytics" version="9.2.0" targetFramework="net471" />
   <package id="Sitecore.ExperienceForms" version="9.2.0" targetFramework="net471" />
   <package id="Sitecore.ExperienceForms.Data.SqlServer" version="9.2.0" targetFramework="net471" />
   <package id="Sitecore.ExperienceForms.Mvc" version="9.2.0" targetFramework="net471" />
+  <package id="Sitecore.Framework.Conditions" version="4.0.0" targetFramework="net471" />
   <package id="Sitecore.Kernel" version="9.2.0" targetFramework="net471" />
   <package id="Sitecore.XConnect" version="9.2.0" targetFramework="net471" />
   <package id="Sitecore.XConnect.Client" version="9.2.0" targetFramework="net471" />
+  <package id="Sitecore.XConnect.Service.Plugins" version="9.2.0" targetFramework="net471" />
   <package id="Sitecore.Xdb.MarketingAutomation.Core" version="9.2.0" targetFramework="net471" />
+  <package id="System.Buffers" version="4.4.0" targetFramework="net471" />
+  <package id="System.ComponentModel.Annotations" version="4.7.0" targetFramework="net471" />
+  <package id="System.Interactive.Async" version="3.1.1" targetFramework="net471" />
+  <package id="System.Interactive.Async.Providers" version="3.1.1" targetFramework="net471" />
+  <package id="System.Memory" version="4.5.2" targetFramework="net471" />
+  <package id="System.Numerics.Vectors" version="4.4.0" targetFramework="net471" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.7.1" targetFramework="net471" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.2" targetFramework="net471" />
 </packages>

--- a/Habitat demo/src/Project/xConnect/code/App_data/config/sitecore/Collection/sc.XConnect.Service.Plugins.FormsAnonymize.xml
+++ b/Habitat demo/src/Project/xConnect/code/App_data/config/sitecore/Collection/sc.XConnect.Service.Plugins.FormsAnonymize.xml
@@ -1,0 +1,15 @@
+﻿<Settings>
+  <Sitecore>
+    <XConnect>
+      <Collection>
+        <Services>
+          <EraseFormSubmissionWhenExecutingRightToBeForgotten>
+            <Type>Sitecore.Weareyou.Feature.FormsExtension.XConnectServicePlugin.EraseFormSubmissionWhenExecutingRightToBeForgotten, Sitecore.Weareyou.Feature.FormsExtension</Type>
+            <As>Sitecore.XConnect.Service.Plugins.IXConnectServicePlugin, Sitecore.XConnect.Service.Plugins</As>
+            <LifeTime>Singleton</LifeTime>
+          </EraseFormSubmissionWhenExecutingRightToBeForgotten>
+        </Services>
+      </Collection>
+    </XConnect>
+  </Sitecore>
+</Settings>

--- a/Habitat demo/src/Project/xConnect/code/Sitecore.HabitatHome.XConnect.csproj
+++ b/Habitat demo/src/Project/xConnect/code/Sitecore.HabitatHome.XConnect.csproj
@@ -70,6 +70,7 @@
     <Content Include="App_data\jobs\continuous\IndexWorker\App_data\Config\Sitecore\SearchIndexer\sc.Xdb.Collection.IndexerSettings.xml" />
     <Content Include="App_data\Models\Sitecore.Demo.Foundation.Accounts.Models.AccountCollectionModel, 1.0.json" />
     <Content Include="App_data\jobs\continuous\IndexWorker\App_data\Models\Sitecore.Demo.Foundation.Accounts.Models.AccountCollectionModel, 1.0.json" />
+    <Content Include="App_data\config\sitecore\Collection\sc.XConnect.Service.Plugins.FormsAnonymize.xml" />
     <None Include="App_data\jobs\continuous\AutomationEngine\App_Config\ConnectionStrings.config.xdt" />
     <None Include="Properties\PublishProfiles\CustomProfile.pubxml" />
     <None Include="Web.Debug.config">


### PR DESCRIPTION
This PR implements execution "Right to be forgotten" on Sitecore Forms after rightToBeForgottenOperation is executed by xConnect(e.g. Sitecore > xProfile > Any contact > Action > Anonymize. Or by code.)

Code was tested on Sitecore 9.3, however PR was downgraded to Sitecore 9.2 to support same version as original source.